### PR TITLE
✨ Default scroll, in day and week view, to a configurable hour

### DIFF
--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -4,12 +4,23 @@ import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
 import type * as React from "react";
 
 import { cn } from "@/lib/utils";
+import { useLayoutEffect, useRef } from "react";
 
 function ScrollArea({
 	className,
 	children,
+	scrollPosition = 0,
 	...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root> & {
+	scrollPosition?: number;
+}) {
+	const viewportRef = useRef<HTMLDivElement>(null);
+
+	useLayoutEffect(() => {
+		if (viewportRef.current) {
+			viewportRef.current.scrollTop = scrollPosition;
+		}
+	}, [scrollPosition]);
 	return (
 		<ScrollAreaPrimitive.Root
 			data-slot="scroll-area"
@@ -17,6 +28,7 @@ function ScrollArea({
 			{...props}
 		>
 			<ScrollAreaPrimitive.Viewport
+				ref={viewportRef}
 				data-slot="scroll-area-viewport"
 				className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
 			>

--- a/src/features/calendar/contexts/calendar-context.tsx
+++ b/src/features/calendar/contexts/calendar-context.tsx
@@ -14,6 +14,8 @@ interface ICalendarContext {
   setAgendaModeGroupBy: (groupBy: "date" | "color") => void;
   use24HourFormat: boolean;
   toggleTimeFormat: () => void;
+  startOfDayHour: number;
+  setStartOfDayHour: (newVal: number) => void;
   setSelectedDate: (date: Date | undefined) => void;
   selectedUserId: IUser["id"] | "all";
   setSelectedUserId: (userId: IUser["id"] | "all") => void;
@@ -34,13 +36,20 @@ interface CalendarSettings {
   badgeVariant: "dot" | "colored";
   view: TCalendarView;
   use24HourFormat: boolean;
+  startOfDayHour: number;
   agendaModeGroupBy: "date" | "color";
 }
+
+export const MIN_SCROLL_HOUR = 0;
+// With a fixed calendar height, having 16h on top
+// of the frame allows to see the rest of the day
+export const MAX_SCROLL_HOUR = 16;
 
 const DEFAULT_SETTINGS: CalendarSettings = {
   badgeVariant: "colored",
   view: "day",
   use24HourFormat: true,
+  startOfDayHour: 8,
   agendaModeGroupBy: "date",
 };
 
@@ -59,14 +68,15 @@ export function CalendarProvider({
   view?: TCalendarView;
   badge?: "dot" | "colored";
 }) {
-  const [settings, setSettings] = useLocalStorage<CalendarSettings>(
-    "calendar-settings",
-    {
-      ...DEFAULT_SETTINGS,
-      badgeVariant: badge,
-      view: view,
-    },
-  );
+
+  const [rawSettings, setSettings] = useLocalStorage<Partial<CalendarSettings>>("calendar-settings", {});
+
+  const settings: CalendarSettings = {
+    ...DEFAULT_SETTINGS,
+    badgeVariant: badge,
+    view: view,
+    ...rawSettings,
+  };
 
   const [badgeVariant, setBadgeVariantState] = useState<"dot" | "colored">(
     settings.badgeVariant,
@@ -76,6 +86,9 @@ export function CalendarProvider({
   );
   const [use24HourFormat, setUse24HourFormatState] = useState<boolean>(
     settings.use24HourFormat,
+  );
+  const [startOfDayHour, setStartOfDayHourState] = useState<number>(
+    settings.startOfDayHour,
   );
   const [agendaModeGroupBy, setAgendaModeGroupByState] = useState<
     "date" | "color"
@@ -91,10 +104,10 @@ export function CalendarProvider({
   const [filteredEvents, setFilteredEvents] = useState<IEvent[]>(events || []);
 
   const updateSettings = (newPartialSettings: Partial<CalendarSettings>) => {
-    setSettings({
-      ...settings,
+    setSettings((prev) => ({
+      ...prev,
       ...newPartialSettings,
-    });
+    }));
   };
 
   const setBadgeVariant = (variant: "dot" | "colored") => {
@@ -112,6 +125,14 @@ export function CalendarProvider({
     setUse24HourFormatState(newValue);
     updateSettings({ use24HourFormat: newValue });
   };
+
+  const setStartOfDayHour = (newVal: number) => {
+    if (!isNaN(newVal) && newVal >= MIN_SCROLL_HOUR && newVal <= MAX_SCROLL_HOUR) {
+      setStartOfDayHourState(newVal);
+      updateSettings({ startOfDayHour: newVal });
+    }
+  };
+
 
   const setAgendaModeGroupBy = (groupBy: "date" | "color") => {
     setAgendaModeGroupByState(groupBy);
@@ -196,6 +217,8 @@ export function CalendarProvider({
     view: currentView,
     use24HourFormat,
     toggleTimeFormat,
+    startOfDayHour,
+    setStartOfDayHour,
     setView,
     agendaModeGroupBy,
     setAgendaModeGroupBy,

--- a/src/features/calendar/helpers.ts
+++ b/src/features/calendar/helpers.ts
@@ -36,6 +36,7 @@ import type {
 } from "@/features/calendar/types";
 
 const FORMAT_STRING = "MMM d, yyyy";
+export const HOUR_HEIGHT_PX = 96;
 
 export function rangeText(view: TCalendarView, date: Date): string {
 	let start: Date;
@@ -438,4 +439,9 @@ export const useGetEventsByMode = (events: IEvent[]) => {
 export const toCapitalize = (str: string): string => {
 	if (!str) return "";
 	return str.charAt(0).toUpperCase() + str.slice(1);
+};
+
+export const useScrollPosition = () => {
+	const { startOfDayHour } = useCalendar();
+	return startOfDayHour * HOUR_HEIGHT_PX;
 };

--- a/src/features/calendar/hooks.ts
+++ b/src/features/calendar/hooks.ts
@@ -17,7 +17,7 @@ export function useDisclosure({
 export const useLocalStorage = <T>(
 	key: string,
 	initialValue: T,
-): [T, (value: T) => void] => {
+): [T, (value: T | ((prev: T) => T)) => void] => {
 	const readValue = (): T => {
 		if (typeof window === "undefined") {
 			return initialValue;
@@ -34,7 +34,7 @@ export const useLocalStorage = <T>(
 
 	const [storedValue, setStoredValue] = useState<T>(readValue);
 
-	const setValue = (value: T) => {
+	const setValue = (value: T | ((prev: T) => T)) => {
 		try {
 			const valueToStore =
 				value instanceof Function ? value(storedValue) : value;

--- a/src/features/calendar/settings/settings.tsx
+++ b/src/features/calendar/settings/settings.tsx
@@ -20,7 +20,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Switch } from "@/components/ui/switch";
-import { useCalendar } from "@/features/calendar/contexts/calendar-context";
+import { MAX_SCROLL_HOUR, MIN_SCROLL_HOUR, useCalendar } from "@/features/calendar/contexts/calendar-context";
+import { Input } from "@/components/ui/input";
+import { ChangeEvent } from "react";
 
 export function Settings() {
   const {
@@ -28,6 +30,8 @@ export function Settings() {
     setBadgeVariant,
     use24HourFormat,
     toggleTimeFormat,
+    startOfDayHour,
+    setStartOfDayHour,
     agendaModeGroupBy,
     setAgendaModeGroupBy,
   } = useCalendar();
@@ -35,6 +39,13 @@ export function Settings() {
 
   const isDarkMode = theme === "dark";
   const isDotVariant = badgeVariant === "dot";
+
+  const onChangeStartOfDay = (e: ChangeEvent<HTMLInputElement>) => {
+    const val = parseInt(e.target.value, 10);
+    if (!isNaN(val) && val >= MIN_SCROLL_HOUR && val <= MAX_SCROLL_HOUR) {
+      setStartOfDayHour(val);
+    }
+  };
 
   return (
     <DropdownMenu>
@@ -136,6 +147,20 @@ export function Settings() {
                 onCheckedChange={toggleTimeFormat}
               />
             </DropdownMenuShortcut>
+          </DropdownMenuItem>
+          <DropdownMenuItem>
+            Days start at
+            <DropdownMenuShortcut>
+              <Input
+                type="number"
+                value={startOfDayHour}
+                max={MAX_SCROLL_HOUR}
+                min={MIN_SCROLL_HOUR}
+                onChange={onChangeStartOfDay}
+                className="w-16"
+              />
+            </DropdownMenuShortcut>
+            h
           </DropdownMenuItem>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />

--- a/src/features/calendar/views/week-and-day-view/calendar-day-view.tsx
+++ b/src/features/calendar/views/week-and-day-view/calendar-day-view.tsx
@@ -7,7 +7,7 @@ import { useCalendar } from "@/features/calendar/contexts/calendar-context";
 
 import { AddEditEventDialog } from "@/features/calendar/dialogs/add-edit-event-dialog";
 import { DroppableArea } from "@/features/calendar/dnd/droppable-area";
-import { groupEvents } from "@/features/calendar/helpers";
+import { groupEvents, HOUR_HEIGHT_PX, useScrollPosition } from "@/features/calendar/helpers";
 import type { IEvent } from "@/features/calendar/interfaces";
 import { CalendarTimeline } from "@/features/calendar/views/week-and-day-view/calendar-time-line";
 import { DayViewMultiDayEventsRow } from "@/features/calendar/views/week-and-day-view/day-view-multi-day-events-row";
@@ -21,6 +21,7 @@ interface IProps {
 export function CalendarDayView({ singleDayEvents, multiDayEvents }: IProps) {
   const { selectedDate, setSelectedDate, users, use24HourFormat } =
     useCalendar();
+  const scrollPosition = useScrollPosition();
   const scrollAreaRef = useRef<HTMLDivElement>(null);
 
   const hours = Array.from({ length: 24 }, (_, i) => i);
@@ -98,13 +99,12 @@ export function CalendarDayView({ singleDayEvents, multiDayEvents }: IProps) {
             </span>
           </div>
         </div>
-
-        <ScrollArea className="h-[800px]" type="always" ref={scrollAreaRef}>
+        <ScrollArea className="h-[800px]" type="always" ref={scrollAreaRef} scrollPosition={scrollPosition}>
           <div className="flex">
             {/* Hours column */}
             <div className="relative w-18">
               {hours.map((hour, index) => (
-                <div key={hour} className="relative" style={{ height: "96px" }}>
+                <div key={hour} className="relative" style={{ height: `${HOUR_HEIGHT_PX}px` }}>
                   <div className="absolute -top-3 right-2 flex h-6 items-center">
                     {index !== 0 && (
                       <span className="text-xs text-t-quaternary">
@@ -126,7 +126,7 @@ export function CalendarDayView({ singleDayEvents, multiDayEvents }: IProps) {
                   <div
                     key={hour}
                     className="relative"
-                    style={{ height: "96px" }}
+                    style={{ height: `${HOUR_HEIGHT_PX}px` }}
                   >
                     {index !== 0 && (
                       <div className="pointer-events-none absolute inset-x-0 top-0 border-b"></div>

--- a/src/features/calendar/views/week-and-day-view/calendar-week-view.tsx
+++ b/src/features/calendar/views/week-and-day-view/calendar-week-view.tsx
@@ -9,7 +9,7 @@ import {
 import {useCalendar} from "@/features/calendar/contexts/calendar-context";
 import {AddEditEventDialog} from "@/features/calendar/dialogs/add-edit-event-dialog";
 import {DroppableArea} from "@/features/calendar/dnd/droppable-area";
-import {groupEvents} from "@/features/calendar/helpers";
+import {groupEvents, HOUR_HEIGHT_PX, useScrollPosition} from "@/features/calendar/helpers";
 import type {IEvent} from "@/features/calendar/interfaces";
 import {CalendarTimeline} from "@/features/calendar/views/week-and-day-view/calendar-time-line";
 import {RenderGroupedEvents} from "@/features/calendar/views/week-and-day-view/render-grouped-events";
@@ -25,6 +25,7 @@ interface IProps {
 
 export function CalendarWeekView({singleDayEvents, multiDayEvents}: IProps) {
     const {selectedDate, use24HourFormat} = useCalendar();
+    const scrollPosition = useScrollPosition();
 
     const weekStart = startOfWeek(selectedDate);
     const weekDays = Array.from({length: 7}, (_, i) => addDays(weekStart, i));
@@ -97,7 +98,7 @@ export function CalendarWeekView({singleDayEvents, multiDayEvents}: IProps) {
 
                 </div>
 
-                <ScrollArea className="h-[736px]" type="always">
+                <ScrollArea className="h-[736px]" scrollPosition={scrollPosition} type="always">
                     <div className="flex">
                         {/* Hours column */}
                         <motion.div className="relative w-18" variants={staggerContainer}>
@@ -105,7 +106,7 @@ export function CalendarWeekView({singleDayEvents, multiDayEvents}: IProps) {
                                 <motion.div
                                     key={hour}
                                     className="relative"
-                                    style={{height: "96px"}}
+                                    style={{height: `${HOUR_HEIGHT_PX}px`}}
                                     initial={{opacity: 0, x: -20}}
                                     animate={{opacity: 1, x: 0}}
                                     transition={{delay: index * 0.02, ...transition}}
@@ -150,7 +151,7 @@ export function CalendarWeekView({singleDayEvents, multiDayEvents}: IProps) {
                                                 <motion.div
                                                     key={hour}
                                                     className="relative"
-                                                    style={{height: "96px"}}
+                                                    style={{height: `${HOUR_HEIGHT_PX}px`}}
                                                     initial={{opacity: 0}}
                                                     animate={{opacity: 1}}
                                                     transition={{delay: index * 0.01, ...transition}}


### PR DESCRIPTION
Hello 👋 

Looking at week and day view, some people were having the impression that there wasn't any event until they realized they had to scroll to the working hours.

This PR adds a setting for the hour at which the day is meant to start. Then the day and week views are scrolled by default to match this setting.

I hope you like it